### PR TITLE
Fix pointer math.

### DIFF
--- a/garando_syntax/src/ext/source_util.rs
+++ b/garando_syntax/src/ext/source_util.rs
@@ -117,10 +117,13 @@ pub fn expand_include<'cx>(
             while self.p.token != token::Eof {
                 match panictry!(self.p.parse_item()) {
                     Some(item) => ret.push(item),
-                    None => panic!("{}", self.p.diagnostic().span_fatal(
-                        self.p.span,
-                        &format!("expected item, found `{}`", self.p.this_token_to_string())
-                    )),
+                    None => panic!(
+                        "{}",
+                        self.p.diagnostic().span_fatal(
+                            self.p.span,
+                            &format!("expected item, found `{}`", self.p.this_token_to_string())
+                        )
+                    ),
                 }
             }
             Some(ret)

--- a/garando_syntax/src/ext/tt/macro_rules.rs
+++ b/garando_syntax/src/ext/tt/macro_rules.rs
@@ -216,14 +216,18 @@ pub fn compile(sess: &ParseSess, def: &ast::Item) -> SyntaxExtension {
         Success(m) => m,
         Failure(sp, tok) => {
             let s = parse_failure_msg(tok);
-            panic!("{}", sess
-                .span_diagnostic
-                .span_fatal(sp.substitute_dummy(def.span), &s));
+            panic!(
+                "{}",
+                sess.span_diagnostic
+                    .span_fatal(sp.substitute_dummy(def.span), &s)
+            );
         }
         Error(sp, s) => {
-            panic!("{}", sess
-                .span_diagnostic
-                .span_fatal(sp.substitute_dummy(def.span), &s));
+            panic!(
+                "{}",
+                sess.span_diagnostic
+                    .span_fatal(sp.substitute_dummy(def.span), &s)
+            );
         }
     };
 
@@ -292,10 +296,7 @@ pub fn compile(sess: &ParseSess, def: &ast::Item) -> SyntaxExtension {
     }
 }
 
-fn check_lhs_nt_follows(
-    sess: &ParseSess,
-    lhs: &quoted::TokenTree,
-) -> bool {
+fn check_lhs_nt_follows(sess: &ParseSess, lhs: &quoted::TokenTree) -> bool {
     // lhs is going to be like TokenTree::Delimited(...), where the
     // entire lhs is those tts. Or, it can be a "bare sequence", not wrapped in parens.
     if let quoted::TokenTree::Delimited(_, ref tts) = *lhs {
@@ -354,10 +355,7 @@ fn check_rhs(sess: &ParseSess, rhs: &quoted::TokenTree) -> bool {
     false
 }
 
-fn check_matcher(
-    sess: &ParseSess,
-    matcher: &[quoted::TokenTree],
-) -> bool {
+fn check_matcher(sess: &ParseSess, matcher: &[quoted::TokenTree]) -> bool {
     let first_sets = FirstSets::new(matcher);
     let empty_suffix = TokenSet::empty();
     let err = sess.span_diagnostic.err_count();
@@ -896,9 +894,7 @@ fn is_in_follow(tok: &quoted::TokenTree, frag: &str) -> Result<bool, (String, &'
     }
 }
 
-fn has_legal_fragment_specifier(
-    tok: &quoted::TokenTree,
-) -> Result<(), String> {
+fn has_legal_fragment_specifier(tok: &quoted::TokenTree) -> Result<(), String> {
     debug!("has_legal_fragment_specifier({:?})", tok);
     if let quoted::TokenTree::MetaVarDecl(_, _, ref frag_spec) = *tok {
         let frag_name = frag_spec.name.as_str();
@@ -909,9 +905,7 @@ fn has_legal_fragment_specifier(
     Ok(())
 }
 
-fn is_legal_fragment_specifier(
-    frag_name: &str,
-) -> bool {
+fn is_legal_fragment_specifier(frag_name: &str) -> bool {
     match frag_name {
         "item" | "block" | "stmt" | "expr" | "pat" | "path" | "ty" | "ident" | "meta" | "tt"
         | "vis" | "" => true,

--- a/garando_syntax/src/ext/tt/transcribe.rs
+++ b/garando_syntax/src/ext/tt/transcribe.rs
@@ -136,12 +136,15 @@ pub fn transcribe(
                     &repeats,
                 ) {
                     LockstepIterSize::Unconstrained => {
-                        panic!("{}", sp_diag.span_fatal(
-                            sp, /* blame macro writer */
-                            "attempted to repeat an expression \
+                        panic!(
+                            "{}",
+                            sp_diag.span_fatal(
+                                sp, /* blame macro writer */
+                                "attempted to repeat an expression \
                              containing no syntax \
                              variables matched as repeating at this depth"
-                        ));
+                            )
+                        );
                     }
                     LockstepIterSize::Contradiction(ref msg) => {
                         // FIXME #2887 blame macro invoker instead
@@ -151,7 +154,10 @@ pub fn transcribe(
                         if len == 0 {
                             if seq.op == quoted::KleeneOp::OneOrMore {
                                 // FIXME #2887 blame invoker
-                                panic!("{}", sp_diag.span_fatal(sp, "this must repeat at least once"));
+                                panic!(
+                                    "{}",
+                                    sp_diag.span_fatal(sp, "this must repeat at least once")
+                                );
                             }
                         } else {
                             repeats.push((0, len));
@@ -179,10 +185,16 @@ pub fn transcribe(
                                 }
                             }
                         } else {
-                            panic!("{}", sp_diag.span_fatal(
-                                sp, /* blame the macro writer */
-                                &format!("variable '{}' is still repeating at this depth", ident)
-                            ));
+                            panic!(
+                                "{}",
+                                sp_diag.span_fatal(
+                                    sp, /* blame the macro writer */
+                                    &format!(
+                                        "variable '{}' is still repeating at this depth",
+                                        ident
+                                    )
+                                )
+                            );
                         }
                     }
                 }

--- a/garando_syntax/src/util/move_map.rs
+++ b/garando_syntax/src/util/move_map.rs
@@ -29,13 +29,13 @@ impl<T> MoveMap<T> for Vec<T> {
             while read_i < old_len {
                 // move the read_i'th item out of the vector and map it
                 // to an iterator
-                let e = ptr::read(self.get_unchecked(read_i));
+                let e = ptr::read(self.as_mut_ptr().offset(read_i as isize));
                 let iter = f(e).into_iter();
                 read_i += 1;
 
                 for e in iter {
                     if write_i < read_i {
-                        ptr::write(self.get_unchecked_mut(write_i), e);
+                        ptr::write(self.as_mut_ptr().offset(write_i as isize), e);
                         write_i += 1;
                     } else {
                         // If this is reached we ran out of space


### PR DESCRIPTION
The previous use of `get_unchecked` was UB according to
https://doc.rust-lang.org/nightly/std/primitive.slice.html#safety-2
and https://github.com/rust-lang/rust/pull/120594 exposed this leading
to a panic caught by tests as:
```
cargo test --all
...
thread 'fold::tests::ident_transformation_in_defs' panicked at library/core/src/panicking.rs:155:5:
unsafe precondition(s) violated: hint::assert_unchecked must never be called when the condition is false
thread caused non-unwinding panic. aborting.
error: test failed, to rerun pass `-p garando_syntax --lib`
...
```

Fixes https://github.com/rust-lang/rust/issues/120910